### PR TITLE
Kindle Fire compatibility

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -3,7 +3,13 @@
     var indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB,
         IDBDatabase = window.IDBDatabase || window.webkitIDBDatabase,
         IDBKeyRange = window.IDBKeyRange || window.webkitIDBKeyRange,
-        transactionModes = {
+        transactionModes = (window.IDBTransaction && window.IDBTransaction.READ_WRITE) ? {
+            readonly: window.IDBTransaction.READ_ONLY,
+            readwrite: window.IDBTransaction.READ_WRITE
+        } : (window.webkitIDBTransaction && window.webkitIDBTransaction.READ_WRITE) ? {
+            readonly: window.webkitIDBTransaction.READ_ONLY,
+            readwrite: window.webkitIDBTransaction.READ_WRITE
+        } : {
             readonly: 'readonly',
             readwrite: 'readwrite'
         };


### PR DESCRIPTION
I'm not expecting this pull request to be approved. Just thought I'd mention somewhere that Kindle Fire uses an old copy of Chrome for its Amazon Silk browser. It's nearly impossible to debug, but I finally figured out that the callback was setVersion and the readonly setting expected the old integer constants. So I've made those respective hacks to the current db.js code, in case anyone wants them.
