### PR TITLE
Allow adding indexes to an existing object store

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -438,11 +438,12 @@
         
         for ( var tableName in schema ) {
             var table = schema[ tableName ];
-            if ( !hasOwn.call( schema , tableName ) || db.objectStoreNames.contains( tableName ) ) {
-                continue;
+            var store;
+            if (!hasOwn.call(schema, tableName) || db.objectStoreNames.contains(tableName)) {
+                store = e.currentTarget.transaction.objectStore(tableName);
+            } else {
+                store = db.createObjectStore(tableName, table.key);
             }
-
-            var store = db.createObjectStore( tableName , table.key );
 
             for ( var indexKey in table.indexes ) {
                 var index = table.indexes[ indexKey ];

--- a/tests/specs/indexes.js
+++ b/tests/specs/indexes.js
@@ -114,6 +114,74 @@
                 return done;
             } , 1000 , 'timed out running specs' );
         });
-    });
+
+        it( 'should allow adding indexes to an existing object store' , function () {
+            var spec = this;
+            runs( function () {
+                db.open( {
+                    server: dbName ,
+                    version: 1,
+                    schema: { 
+                        test: {
+                            key: {
+                                keyPath: 'id',
+                                autoIncrement: true
+                            },
+                        }
+                    }
+                }).done(function ( s ) {
+                    s.close();
+					
+                    db.open( {
+                        server: dbName,
+                        version: 2,
+						schema: { 
+							test: {
+								key: {
+									keyPath: 'id',
+									autoIncrement: true
+								},
+								indexes: {
+									firstName: { },
+									age: { }
+								}
+							}
+						}
+                    }).done(function ( s ) {
+						spec.server = s;
+                    });
+                });
+            });
+
+            waitsFor( function () {
+                return !!spec.server;
+            } , 1000 , 'timed out opening the db' );
+			
+            var done = false;
+            runs( function () {
+                spec.server.close();
+
+                var req = indexedDB.open( dbName , 2 );
+                req.onsuccess = function ( e ) {
+                    var res = e.target.result;
+
+                    var transaction = res.transaction( 'test' );
+                    var store = transaction.objectStore( 'test' );
+                    var indexNames = Array.prototype.slice.call( store.indexNames );
+
+                    expect( indexNames.length ).toEqual( 2 );
+                    expect( indexNames ).toContain( 'firstName' );
+                    expect( indexNames ).toContain( 'age' );
+
+                    spec.server = res;
+                    done = true;
+                };
+            });
+
+            waitsFor( function () {
+                return done;
+            } , 1000 , 'timed out running specs' );
+        });
+		});
 
 })( window.db , window.describe , window.it , window.runs , window.expect , window.waitsFor , window.beforeEach , window.afterEach );


### PR DESCRIPTION
Pull request #38 has an unwanted side effect in that you cannot add new indexes to an already existing ObjectStore With this change and spec adding indexes is possible again.
