### PR TITLE
Attempted fix for adding an index to a datastore with indexes

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -535,6 +535,10 @@
             }
 
             for ( var indexKey in table.indexes ) {
+                if (store.indexNames.contains(indexKey)) {
+                    continue;
+                }
+                
                 var index = table.indexes[ indexKey ];
                 store.createIndex( indexKey , index.key || indexKey , Object.keys(index).length ? index : { unique: false } );
             }

--- a/tests/specs/indexes.js
+++ b/tests/specs/indexes.js
@@ -182,6 +182,77 @@
                 return done;
             } , 1000 , 'timed out running specs' );
         });
+
+        it( 'should allow adding indexes to an existing object store with indexes' , function () {
+            var spec = this;
+            runs( function () {
+                db.open( {
+                    server: dbName ,
+                    version: 1,
+                    schema: { 
+                        test: {
+                            key: {
+                                keyPath: 'id',
+                                autoIncrement: true
+                            },
+                            indexes: {
+                                firstName: {}
+                            }
+                        }
+                    }
+                }).done(function ( s ) {
+                    s.close();
+                    
+                    db.open( {
+                        server: dbName,
+                        version: 2,
+                        schema: { 
+                            test: {
+                                key: {
+                                    keyPath: 'id',
+                                    autoIncrement: true
+                                },
+                                indexes: {
+                                    firstName: { },
+                                    age: { }
+                                }
+                            }
+                        }
+                    }).done(function ( s ) {
+                        spec.server = s;
+                    });
+                });
+            });
+
+            waitsFor( function () {
+                return !!spec.server;
+            } , 1000 , 'timed out opening the db' );
+            
+            var done = false;
+            runs( function () {
+                spec.server.close();
+
+                var req = indexedDB.open( dbName , 2 );
+                req.onsuccess = function ( e ) {
+                    var res = e.target.result;
+
+                    var transaction = res.transaction( 'test' );
+                    var store = transaction.objectStore( 'test' );
+                    var indexNames = Array.prototype.slice.call( store.indexNames );
+
+                    expect( indexNames.length ).toEqual( 2 );
+                    expect( indexNames ).toContain( 'firstName' );
+                    expect( indexNames ).toContain( 'age' );
+
+                    spec.server = res;
+                    done = true;
+                };
+            });
+
+            waitsFor( function () {
+                return done;
+            } , 1000 , 'timed out running specs' );
+        });
 		});
 
 })( window.db , window.describe , window.it , window.runs , window.expect , window.waitsFor , window.beforeEach , window.afterEach );


### PR DESCRIPTION
I have a datastore with indexes, and when I update the datastore by adding indexes, I get an error on the line store.createIndex... that an index with the given name already exists.

I had a lot of trouble getting the test suite to run as I mentioned in issue #61, but I believe this test would fail and that this fix solves it. Please test it yourself before merging, the travis tests don't seem to run on forked repos or pull requests.
