### PR TITLE
Server.add now supports arrays

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -1,13 +1,6 @@
 (function ( window , undefined ) {
     'use strict';
 
-    // only implement if no native implementation is available
-    if (typeof Array.isArray === 'undefined') {
-        Array.isArray = function(obj) {
-            return Object.toString.call(obj) === '[object Array]';
-        };
-    }
-
     var indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB,
         IDBKeyRange = window.IDBKeyRange || window.webkitIDBKeyRange,
         transactionModes = {

--- a/tests/specs/server-add.js
+++ b/tests/specs/server-add.js
@@ -375,6 +375,39 @@
             });
         });
 
+        it( 'should insert multiple items into the object store, using an array' , function () {
+            var items = [
+                {
+                    firstName: 'Aaron',
+                    lastName: 'Powell'
+                },
+                {
+                    firstName: 'Aaron',
+                    lastName: 'Powell'
+                }
+            ];
+            
+            var spec = this;
+            var done;
+            
+            runs( function () {
+                spec.server.add( 'test' , items ).done( function ( records ) {
+                    done = true;
+                });
+            });
+            
+            waitsFor( function () {
+                return done;
+            } , 'timeout waiting for item to be added' , 1000 );
+            
+            runs( function () {
+                expect( items[0].__id__ ).toBeDefined();
+                expect( items[0].__id__ ).toEqual( 1 );
+                expect( items[1].__id__ ).toBeDefined();
+                expect( items[1].__id__ ).toEqual( 2 );
+            });
+        });
+
         it( 'should insert an item with a provided key into the object store' , function () {
             var item1 = {
                 firstName: 'Aaron',


### PR DESCRIPTION
"Fixes" #22 without breaking the current splat system. I feel like this might be considered more "sane" by any JS developers who like to code in a more traditional style than splatting arguments out (which, honestly, with the insane (30k+ item array from a JSON call) dataset sizes I was dealing with, would have been a mess).

Does modify a browser prototype at the moment, I could refactor that if you're terribly opposed to it.
