### PR TITLE
Added possibility to filter with object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ server.people.clear()
 	          // do something with the results
 	      } );
 
+filter accepts `key,value`, `function` and `object` 
+
 ### Querying using indexes
 
 All ranges supported by IDBKeyRange can be used.

--- a/src/db.js
+++ b/src/db.js
@@ -374,7 +374,29 @@
                 };
             };
             var filter = function ( ) {
-                filters.push( Array.prototype.slice.call( arguments , 0 , 2 ) );
+                
+                var filterObject = typeof arguments[0] === 'object' ? arguments[0] : false;
+                
+                if(filterObject) {
+                    var f = function(x){
+                        var hasAllProps = true;
+                        for (var key in filterObject) {
+                            // Explicitly check that prop is not on filter-objects prototype
+                            if (hasOwn.call(filterObject,key)) {
+                                // Return false if prop does not exist or do not match on record
+                                if(!hasOwn.call(x,key) || x[key] !== filterObject[key]) {
+                                    hasAllProps = false;
+                                }
+                            }
+                        }
+                        return hasAllProps;
+                    }
+
+                    filters.push([f]);
+                    
+                } else {
+                    filters.push( Array.prototype.slice.call( arguments , 0 , 2 ) );
+                }
 
                 return {
                     keys: keys,

--- a/tests/specs/query.js
+++ b/tests/specs/query.js
@@ -230,6 +230,28 @@
                 return done;
             } , 1000 , 'timed out running expects' );
         });
+        it( 'should query using a filter object' , function () {
+            var done;
+            runs( function () {
+                var spec = this;
+                this.server
+                    .query( 'test' )
+                    .filter( {firstName: 'John', lastName: 'Smith'})
+                    .execute()
+                    .then(function ( results ) {
+                        expect( results ).toBeDefined();
+                        expect( results.length ).toEqual( 1 );
+                        expect( results[0].firstName ).toEqual( spec.item2.firstName );
+                        expect( results[0].firstName ).toEqual( spec.item2.firstName );
+
+                        done = true;
+                    });
+            });
+
+            waitsFor( function () {
+                return done;
+            } , 1000 , 'timed out running expects' );
+        });
 
         describe( 'index range query' , function () {
             it( 'should allow matching exact values' , function () {


### PR DESCRIPTION
I found it confusing why the filter would not accept object as filter method. This is now fixed. It generates a function which returns true if record has all and match all properties on the filter object.

Updated README and added tests.