### PR TITLE
Switch to node 0.10 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ before_script:
 - npm install -g grunt-cli
 language: node_js
 node_js:
-- 0.8
+- 0.10
 notifications:
   email: false
 env:


### PR DESCRIPTION
This will make npm install stop failing in Travis. Was using a very old Node.js version.