### PR TITLE
Fix rejection of failed transactions to use only one parameter.

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -115,10 +115,10 @@
                   resolve( records , that );
               };
               transaction.onerror = function ( e ) {
-                  reject( records , e );
+                  reject( e );
               };
               transaction.onabort = function ( e ) {
-                  reject( records , e );
+                  reject( e );
               };
 
             });
@@ -159,10 +159,10 @@
                   resolve( records , that );
               };
               transaction.onerror = function ( e ) {
-                  reject( records , e );
+                  reject( e );
               };
               transaction.onabort = function ( e ) {
-                  reject( records , e );
+                  reject( e );
               };
             });
 

--- a/tests/specs/server-add.js
+++ b/tests/specs/server-add.js
@@ -572,9 +572,9 @@
                     key: key
                 } ).then( function ( records ) {
                     //done = true;
-                }).catch( function ( items , e ) {
-                    done = true;
+                }).catch( function ( e ) {
                     expect( e.target.error.name ).toBe( 'ConstraintError' );
+                    done = true;
                 });
             });
 


### PR DESCRIPTION
Belonging to https://github.com/aaronpowell/db.js/issues/97.

I also fixed a test as it wasn't failing correctly after making the reject changes (which actually wasn't failing as it should have).