### PR TITLE
Resolve "Uncaught SyntaxError" in some devices

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -176,7 +176,7 @@
                 store = transaction.objectStore( table );
 
             return new Promise(function(resolve, reject){
-              var req = store.delete( key );
+              var req = store['delete']( key );
               transaction.oncomplete = function ( ) {
                   resolve( key );
               };
@@ -321,7 +321,7 @@
                                 cursor.update(result);
                             }
                         }
-                        cursor.continue();
+                        cursor['continue']();
                     }
                 }
             };


### PR DESCRIPTION
Some devices like Android 2.x doesn't like to use reserved tokens in dot (.) notation. They can be used in [''] notation.
It adds compatibility and works for the others. Resolves issue https://github.com/aaronpowell/db.js/issues/76

See also discussion here: https://github.com/mozilla/localForage/issues/201