### PR TITLE
Make a way to access the underlying IndexedDB.

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -64,6 +64,10 @@
         var that = this,
             closed = false;
 
+		this.getIndexedDB = function () {
+			return db;
+		};
+
         this.add = function( table ) {
             if ( closed ) {
                 throw 'Database has been closed';


### PR DESCRIPTION
I have found sometimes for performance, or data consistency reasons, I need to access the IndexedDB and use it directly. For example, I needed to insert ~300 records into the object store and get the ID's generated, then update each of those records to reflect the relations between those entries. This is done much more effectively with a single transaction.

This pull request just adds a function to return the private IndexDB being used. It should probably also include a warning about the potential dangers of using it.