### PR TITLE
Allow package.json to be self-sufficient for Travis builds and to all…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-before_script:
-- npm install -g grunt-cli
-- npm install -g bower
-- bower install
 language: node_js
 node_js:
 - 0.12

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "db.js",
-  "version": "0.11.0",
   "main": "dist/db.min.js",
   "homepage": "https://github.com/aaronpowell/db.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "db.js",
   "description": "db.js is a wrapper for IndexedDB to make it easier to work against, making it look more like a queryable API.",
   "version": "0.11.0",
+  "author": "Aaron Powell <me@aaron-powell.com>",
+  "contributors": ["Brett Zamir <brettz9@yahoo.com>"],
   "homepage": "http://aaronpowell.github.com/db.js/",
   "repository": {
     "type": "git",
@@ -17,8 +19,9 @@
   },
   "scripts": {
     "test": "grunt test",
-    "prepublish": "bower install"
+    "prepublish": "npm install -g grunt-cli && npm install -g bower && bower install"
   },
+  "dependencies": {},
   "devDependencies": {
     "babel-preset-es2015": "^6.0.15",
     "eslint-config-standard": "^4.4.0",


### PR DESCRIPTION
…ow users to avoid the need to run a separate "bower install"; remove bower-deprecated version field; package.json linting