### PR TITLE
Support key or range (MongoDB-style, IDBKeyRange) on server.count();

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ The `map` method allows you to modify the object being returned:
 
 ##### Counting
 
+To count while utilizing an index and/or the `query`-returned methods,
+you can use the following:
+
 ```js
     server.people.query('firstName')
         .only('Aaron')
@@ -317,6 +320,31 @@ The `map` method allows you to modify the object being returned:
         .then(function (results) {
             // `results` will equal the total count of "Aaron"'s
         });
+```
+
+If you only need a count of items in a store with only a key or range,
+you can utilize `server.count`:
+
+```js
+// With no arguments (count all items)
+server.people.count().then(function (ct) {
+    // Do something with "ct"
+});
+
+// With a key
+server.people.count(myKey).then(function (ct) {
+    // Do something with "ct"
+});
+
+// With a MongoDB-style range
+server.people.count({gte: 1, lt: 3}).then(function (ct) {
+    // Do something with "ct"
+});
+
+// With an IDBKeyRange range
+server.people.count(IDBKeyRange.bound(1, 3, false, true)).then(function (ct) {
+    // Do something with "ct"
+});
 ```
 
 #### Atomic updates

--- a/README.md
+++ b/README.md
@@ -127,10 +127,32 @@ This allows removing all items in a table/collection:
 
 ### Fetching
 
-#### Getting a single object by ID
+#### Getting a single object by key
 
 ```js
     server.people.get(5)
+        .then(function (results) {
+            // do something with the results
+        });
+```
+
+#### Getting a single object by key range
+
+If more than one match, it will retrieve the first.
+
+With a MongoDB-style range:
+
+```js
+    server.people.get({gte: 1, lt: 3})
+        .then(function (results) {
+            // do something with the results
+        });
+```
+
+With an `IDBKeyRange`:
+
+```js
+    server.people.get(IDBKeyRange.bound(1, 3, false, true))
         .then(function (results) {
             // do something with the results
         });

--- a/src/db.js
+++ b/src/db.js
@@ -221,7 +221,7 @@
             return new Promise((resolve, reject) => {
                 if (key && typeof key === 'object' && !(key instanceof IDBKeyRange)) {
                     let [type, args] = mongoDBToKeyRangeArgs(key);
-                    key = IDBKeyRange[type].apply(null, args);
+                    key = IDBKeyRange[type](...args);
                 }
                 var req = store.count(key);
                 req.onsuccess = e => resolve(e.target.result);
@@ -258,7 +258,7 @@
             var transaction = db.transaction(table, modifyObj ? transactionModes.readwrite : transactionModes.readonly);
             var store = transaction.objectStore(table);
             var index = indexName ? store.index(indexName) : store;
-            var keyRange = type ? IDBKeyRange[type].apply(null, args) : null;
+            var keyRange = type ? IDBKeyRange[type](...args) : null;
             var results = [];
             var indexArgs = [keyRange];
             var counter = 0;
@@ -302,7 +302,7 @@
                             } else if (filter.length === 2) {
                                 matchFilter = matchFilter && (result[filter[0]] === filter[1]);
                             } else {
-                                matchFilter = matchFilter && filter[0].apply(undefined, [result]);
+                                matchFilter = matchFilter && filter[0].call(undefined, result);
                             }
                         });
 

--- a/src/db.js
+++ b/src/db.js
@@ -23,6 +23,41 @@
     const dbCache = {};
     const isArray = Array.isArray;
 
+    function mongoDBToKeyRangeArgs (opts) {
+        var keys = Object.keys(opts).sort();
+        if (keys.length === 1) {
+            var key = keys[0];
+            var val = opts[key];
+            var name, inclusive;
+            switch (key) {
+            case 'eq': name = 'only'; break;
+            case 'gt':
+                name = 'lowerBound';
+                inclusive = true;
+                break;
+            case 'lt':
+                name = 'upperBound';
+                inclusive = true;
+                break;
+            case 'gte': name = 'lowerBound'; break;
+            case 'lte': name = 'upperBound'; break;
+            default: throw new TypeError('`' + key + '` is not valid key');
+            }
+            return [name, [val, inclusive]];
+        }
+        var x = opts[keys[0]];
+        var y = opts[keys[1]];
+        var pattern = keys.join('-');
+
+        switch (pattern) {
+        case 'gt-lt': case 'gt-lte': case 'gte-lt': case 'gte-lte':
+            return ['bound', [x, y, keys[0] === 'gt', keys[1] === 'lt']];
+        default: throw new TypeError(
+          '`' + pattern + '` are conflicted keys'
+        );
+        }
+    }
+
     var Server = function (db, name) {
         var closed = false;
 
@@ -184,7 +219,11 @@
             var store = transaction.objectStore(table);
 
             return new Promise((resolve, reject) => {
-                var req = store.count();
+                if (key && typeof key === 'object' && !(key instanceof IDBKeyRange)) {
+                    let [type, args] = mongoDBToKeyRangeArgs(key);
+                    key = IDBKeyRange[type].apply(null, args);
+                }
+                var req = store.count(key);
                 req.onsuccess = e => resolve(e.target.result);
                 transaction.onerror = e => reject(e);
                 transaction.onabort = e => reject(e);
@@ -400,38 +439,7 @@
         });
 
         this.range = function (opts) {
-            var keys = Object.keys(opts).sort();
-            if (keys.length === 1) {
-                var key = keys[0];
-                var val = opts[key];
-                var name, inclusive;
-                switch (key) {
-                case 'eq': name = 'only'; break;
-                case 'gt':
-                    name = 'lowerBound';
-                    inclusive = true;
-                    break;
-                case 'lt':
-                    name = 'upperBound';
-                    inclusive = true;
-                    break;
-                case 'gte': name = 'lowerBound'; break;
-                case 'lte': name = 'upperBound'; break;
-                default: throw new TypeError('`' + key + '` is not valid key');
-                }
-                return new Query(name, [val, inclusive]);
-            }
-            var x = opts[keys[0]];
-            var y = opts[keys[1]];
-            var pattern = keys.join('-');
-
-            switch (pattern) {
-            case 'gt-lt': case 'gt-lte': case 'gte-lt': case 'gte-lte':
-                return new Query('bound', [x, y, keys[0] === 'gt', keys[1] === 'lt']);
-            default: throw new TypeError(
-              '`' + pattern + '` are conflicted keys'
-            );
-            }
+            return Query.apply(null, mongoDBToKeyRangeArgs(opts));
         };
 
         this.filter = function (...args) {

--- a/src/db.js
+++ b/src/db.js
@@ -302,7 +302,7 @@
                             } else if (filter.length === 2) {
                                 matchFilter = matchFilter && (result[filter[0]] === filter[1]);
                             } else {
-                                matchFilter = matchFilter && filter[0].call(undefined, result);
+                                matchFilter = matchFilter && filter[0](result);
                             }
                         });
 

--- a/src/db.js
+++ b/src/db.js
@@ -344,8 +344,8 @@
                 return runQuery(type, args, cursorType, unique ? direction + 'unique' : direction, limitRange, filters, mapper);
             };
 
-            var limit = function () {
-                limitRange = Array.prototype.slice.call(arguments, 0, 2);
+            var limit = function (...args) {
+                limitRange = args.slice(0, 2);
                 if (limitRange.length === 1) {
                     limitRange.unshift(0);
                 }
@@ -375,8 +375,8 @@
                     map
                 };
             };
-            filter = function () {
-                filters.push(Array.prototype.slice.call(arguments, 0, 2));
+            filter = function (...args) {
+                filters.push(args.slice(0, 2));
 
                 return {
                     keys,

--- a/tests/specs/query.js
+++ b/tests/specs/query.js
@@ -83,10 +83,36 @@
             };
         });
 
-        it('should allow getting by id', function (done) {
+        it('should allow getting by key', function (done) {
             var spec = this;
             this.server
                 .get('test', spec.item1.id)
+                .then(function (x) {
+                    expect(x).toBeDefined();
+                    expect(x.id).toEqual(spec.item1.id);
+                    expect(x.firstName).toEqual(spec.item1.firstName);
+                    expect(x.lastName).toEqual(spec.item1.lastName);
+                    done();
+                });
+        });
+
+        it('should allow getting by key range (MongoDB-style)', function (done) {
+            var spec = this;
+            this.server
+                .get('test', {gte: 1, lt: 3})
+                .then(function (x) {
+                    expect(x).toBeDefined();
+                    expect(x.id).toEqual(spec.item1.id);
+                    expect(x.firstName).toEqual(spec.item1.firstName);
+                    expect(x.lastName).toEqual(spec.item1.lastName);
+                    done();
+                });
+        });
+
+        it('should allow getting by key range (IDBKeyRange)', function (done) {
+            var spec = this;
+            this.server
+                .get('test', IDBKeyRange.bound(1, 3, false, true))
                 .then(function (x) {
                     expect(x).toBeDefined();
                     expect(x.id).toEqual(spec.item1.id);

--- a/tests/specs/server-count.js
+++ b/tests/specs/server-count.js
@@ -1,0 +1,89 @@
+(function (db, describe, it, expect, beforeEach, afterEach) {
+    'use strict';
+    describe('server.count', function () {
+        var dbName = 'tests';
+        var indexedDB = window.indexedDB || window.webkitIndexedDB || window.mozIndexedDB || window.oIndexedDB || window.msIndexedDB;
+
+        beforeEach(function (done) {
+            var spec = this;
+            var request = indexedDB.deleteDatabase(dbName);
+            request.onsuccess = function () {
+                db.open({
+                    server: dbName,
+                    version: 1,
+                    schema: {
+                        test: {
+                            key: {
+                                keyPath: 'id',
+                                autoIncrement: true
+                            }
+                        }
+                    }
+                }).then(function (s) {
+                    spec.server = s;
+                }).then(function () {
+                    spec.item1 = {
+                        firstName: 'Aaron',
+                        lastName: 'Powell',
+                        age: 20
+                    };
+                    spec.item2 = {
+                        firstName: 'John',
+                        lastName: 'Smith',
+                        age: 30
+                    };
+                    spec.item3 = {
+                        firstName: 'Aaron',
+                        lastName: 'Jones',
+                        age: 40
+                    };
+                    spec.server.test.add(spec.item1, spec.item2, spec.item3).then(function () {
+                        done();
+                    });
+                });
+            };
+            request.onerror = function (e) {
+                done(e);
+            };
+            request.onblocked = function (e) {
+                done(e);
+            };
+        });
+        afterEach(function (done) {
+            if (this.server) {
+                this.server.close();
+                setTimeout(done, 0); // For Chrome
+                return;
+            }
+            done();
+        });
+        it('should count the number of items in an object store (no args)', function (done) {
+            var spec = this;
+            spec.server.test.count().then(function (ct) {
+                expect(ct).toEqual(3);
+                done();
+            });
+        });
+        it('should count the number of items in an object store (key)', function (done) {
+            var spec = this;
+            spec.server.test.count(1).then(function (ct) {
+                expect(ct).toEqual(1);
+                done();
+            });
+        });
+        it('should count the number of items in an object store (MongoDB-style range)', function (done) {
+            var spec = this;
+            spec.server.test.count({gte: 1, lt: 3}).then(function (ct) {
+                expect(ct).toEqual(2);
+                done();
+            });
+        });
+        it('should count the number of items in an object store (IDBKeyRange)', function (done) {
+            var spec = this;
+            spec.server.test.count(IDBKeyRange.bound(1, 3, false, true)).then(function (ct) {
+                expect(ct).toEqual(2);
+                done();
+            });
+        });
+    });
+})(window.db, window.describe, window.it, window.expect, window.beforeEach, window.afterEach);

--- a/tests/views/index.jade
+++ b/tests/views/index.jade
@@ -6,6 +6,7 @@ append scripts
     script(src='specs/cmp.js')
     script(src='specs/delete-db.js')
     script(src='specs/server-add.js')
+    script(src='specs/server-count.js')
     script(src='specs/server-update.js')
     script(src='specs/server-remove.js')
     script(src='specs/query.js')

--- a/tests/views/layout.jade
+++ b/tests/views/layout.jade
@@ -15,6 +15,6 @@ html
         script(src='../bower/jasmine/lib/jasmine-core/jasmine-html.js')
         script(src='../bower/jasmine/lib/jasmine-core/boot.js')
         script(src='../bower/jasmine-jsreporter/jasmine-jsreporter.js')
-        script(src='../dist/db.min.js')
+        script(src='../dist/db.js')
         script.
             jasmine.getEnv().addReporter(new jasmine.JSReporter2())

--- a/tests/views/layout.jade
+++ b/tests/views/layout.jade
@@ -15,6 +15,6 @@ html
         script(src='../bower/jasmine/lib/jasmine-core/jasmine-html.js')
         script(src='../bower/jasmine/lib/jasmine-core/boot.js')
         script(src='../bower/jasmine-jsreporter/jasmine-jsreporter.js')
-        script(src='../dist/db.js')
+        script(src='../dist/db.min.js')
         script.
             jasmine.getEnv().addReporter(new jasmine.JSReporter2())


### PR DESCRIPTION
Add server-count tests and docs;
Utilize unminified version in test for easier debugging

I can revert the testing back to using the minified version of db.js if you like, but for testing, I think it makes sense to use the unminified.