### PR TITLE
Delete object stores no longer in schema

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -461,6 +461,19 @@
             schema = schema();
         }
 
+        if (!schema || schema.length === 0) {
+            return;
+        }
+
+        for (var objectStoreKey in db.objectStoreNames) {
+            if (db.objectStoreNames.hasOwnProperty(objectStoreKey)) {
+                var name = db.objectStoreNames[objectStoreKey];
+                if (schema.hasOwnProperty(name) === false) {
+                    e.currentTarget.transaction.db.deleteObjectStore(name);
+                }
+            }
+        }
+
         var tableName;
         for (tableName in schema) {
             var table = schema[tableName];

--- a/tests/specs/open-db.js
+++ b/tests/specs/open-db.js
@@ -186,5 +186,44 @@
                 done(err);
             });
         });
+        
+        it('should remove object stores no longer defined in the schema', function(done){
+            db.open({
+                server: dbName,
+                version: 1,
+                schema: {
+                    test_1: {},
+                    test_2: {}
+                }
+            }).then(function (s) {
+                s.close();
+                
+                db.open({
+                   server: dbName,
+                   version: 2,
+                   schema: {
+                        test_2: {}
+                    }
+                }).then(function(s){
+                    s.close();
+                    
+                    var req = indexedDB.open(dbName);
+                    req.onsuccess = function (e) {
+                        var db = e.target.result;
+
+                        expect(db.objectStoreNames.length).toEqual(1);
+                        expect(db.objectStoreNames[ 0 ]).toEqual('test_2');
+
+                        db.close();
+                        done();
+                    };
+                }, function (err) {
+                    done(err);
+                });
+            }, function (err) {
+                done(err);
+            });
+        });
+        
     });
 }(window.db, window.describe, window.it, window.expect, window.beforeEach, window.afterEach));


### PR DESCRIPTION
When applying a schema for a new version it deletes the object stores from the database not defined in the (new) schema.