### PR TITLE
Allow for consistent promise use (including for errors), deferring th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Queries require one or more methods to determine the type of querying
 (all items, filtering, applying ranges, limits, distinct values, or
 custom mapping--some of which can be combined
 with some of the others), any methods for cursor direction, and then a
-subsequent call to `execute()`.
+subsequent call to `execute()` (followed by a `then` or `catch`).
 
 ##### Querying all objects
 

--- a/src/db.js
+++ b/src/db.js
@@ -193,12 +193,15 @@
         };
 
         this.close = function () {
-            if (closed) {
-                throw new Error('Database has been closed');
-            }
-            db.close();
-            closed = true;
-            delete dbCache[name];
+            return new Promise(function (resolve, reject) {
+                if (closed) {
+                    reject('Database has been closed');
+                }
+                db.close();
+                closed = true;
+                delete dbCache[name];
+                resolve();
+            });
         };
 
         this.get = function (table, key) {
@@ -210,7 +213,11 @@
                 var transaction = db.transaction(table);
                 var store = transaction.objectStore(table);
 
-                key = mongoifyKey(key);
+                try {
+                    key = mongoifyKey(key);
+                } catch (e) {
+                    reject(e);
+                }
                 var req = store.get(key);
                 req.onsuccess = e => resolve(e.target.result);
                 transaction.onerror = e => reject(e);
@@ -219,10 +226,8 @@
         };
 
         this.query = function (table, index) {
-            if (closed) {
-                throw new Error('Database has been closed');
-            }
-            return new IndexQuery(table, db, index);
+            var error = closed ? 'Database has been closed' : null;
+            return new IndexQuery(table, db, index, error);
         };
 
         this.count = function (table, key) {
@@ -233,7 +238,11 @@
                 }
                 var transaction = db.transaction(table);
                 var store = transaction.objectStore(table);
-                key = mongoifyKey(key);
+                try {
+                    key = mongoifyKey(key);
+                } catch (e) {
+                    reject(e);
+                }
                 var req = key === undefined ? store.count() : store.count(key);
                 req.onsuccess = e => resolve(e.target.result);
                 transaction.onerror = e => reject(e);
@@ -262,7 +271,7 @@
         return err;
     };
 
-    var IndexQuery = function (table, db, indexName) {
+    var IndexQuery = function (table, db, indexName, preexistingError) {
         var modifyObj = false;
 
         var runQuery = function (type, args, cursorType, direction, limitRange, filters, mapper) {
@@ -339,15 +348,19 @@
             });
         };
 
-        var Query = function (type, args) {
+        var Query = function (type, args, queuedError) {
             var direction = 'next';
             var cursorType = 'openCursor';
             var filters = [];
             var limitRange = null;
             var mapper = defaultMapper;
             var unique = false;
+            var error = preexistingError || queuedError;
 
             var execute = function () {
+                if (error) {
+                    return Promise.reject(error);
+                }
                 return runQuery(type, args, cursorType, unique ? direction + 'unique' : direction, limitRange, filters, mapper);
             };
 
@@ -462,7 +475,14 @@
         });
 
         this.range = function (opts) {
-            return Query.apply(null, mongoDBToKeyRangeArgs(opts));
+            var error;
+            var keyRange = [null, null];
+            try {
+                keyRange = mongoDBToKeyRangeArgs(opts);
+            } catch (e) {
+                error = e;
+            }
+            return Query(...keyRange, error);
         };
 
         this.filter = function (...args) {


### PR DESCRIPTION
…e error in the case of query preparation until execution

This PR attempts to address item 2 mentioned in the OP of issue #144, i.e., of consistently rejecting in the public API rather than throwing.

Two notes:

1. Although deferring the reporting of the error may not be ideal (in the case of queries), I think this is necessary given how the chaining does not expect promises until the end, and otherwise the user will need to add try-catch blocks.
2. I thought it most consistent to turn `close` into a Promise as with the other `Server` methods (allowing a user to catch an error if a call to it did not first check `isClosed`).